### PR TITLE
fix(ui): don't use InteractionManager#cancel to avoid a crash

### DIFF
--- a/src/ui/polyfills/requestIdleCallback.native.js
+++ b/src/ui/polyfills/requestIdleCallback.native.js
@@ -12,8 +12,11 @@ let id = 0;
 global.Promise.prototype.done = () => {}; // FIXME: Without this InteractionManager throws
 global.requestIdleCallback = (callback: Function) => {
 	const handle = id++;
-	pendingTasks[handle] = InteractionManager.runAfterInteractions(() => {
-		callback();
+	pendingTasks[handle] = true;
+	InteractionManager.runAfterInteractions(() => {
+		if (pendingTasks[handle]) {
+			callback();
+		}
 		delete pendingTasks[handle];
 	});
 	return handle;
@@ -21,7 +24,6 @@ global.requestIdleCallback = (callback: Function) => {
 
 global.cancelIdleCallback = (handle: number) => {
 	if (pendingTasks[handle]) {
-		pendingTasks[handle].cancel();
 		delete pendingTasks[handle];
 	}
 };


### PR DESCRIPTION
`InteractionManager#cancel` can cause a unhandled rejection which crashes the app in production.

https://github.com/facebook/react-native/commit/be09cccb1f2153f84da85214b31cd4cdb4e783ec#commitcomment-18173220
